### PR TITLE
PyTables comparison tools

### DIFF
--- a/spots_reduced.csv
+++ b/spots_reduced.csv
@@ -1,4 +1,4 @@
-,intensity,z,y,x,radius,spot_id,z_min,z_max,y_min,y_max,x_min,x_max,features,xc,yc,zc,target,distance,passes_thresholds
+ID,intensity,z,y,x,radius,spot_id,z_min,z_max,y_min,y_max,x_min,x_max,features,xc,yc,zc,target,distance,passes_thresholds
 0,0.000108445114165,0,2399,1591,4.0,0,0.0,1.0,2396.0,2400.0,1588.0,1595.0,0,1592.6631929970822,2401.0,5e-05,,0.411115055757366,False
 1,8.362327207578346e-06,0,2399,1182,3.0,1,0.0,1.0,2397.0,2400.0,1180.0,1185.0,1,1183.4927052938724,2401.0,5e-05,,0.3885798560709833,False
 2,1.562410034239292e-06,0,2399,752,3.0,2,0.0,1.0,2397.0,2400.0,750.0,755.0,2,753.3134639433097,2401.0,5e-05,,0.2702180392841246,False

--- a/zarr_anndata/pytables_util.py
+++ b/zarr_anndata/pytables_util.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+import numpy as np
+import pandas as pd
+import tables as tb
+import os
+import time
+
+
+def write_pandas(input, output):
+    df = pd.read_csv(input)
+    df.to_hdf(
+        output,
+        key="spots",
+        format="table",
+        mode="w",
+        data_columns=["ID", "z", "y", "x", "target"],
+    )
+
+
+def write_tables(input, output):
+    h5 = tb.open_file(output, "w")
+    data = np.genfromtxt(
+        input,
+        dtype=(
+            [
+                ("ID", "i8"),
+                ("intensity", "f4"),
+                ("z", "i8"),
+                ("y", "i8"),
+                ("x", "i8"),
+                ("radius", "f4"),
+                ("spot_id", "i8"),
+                ("z_min", "f4"),
+                ("z_max", "f4"),
+                ("y_min", "f4"),
+                ("y_max", "f4"),
+                ("x_min", "f4"),
+                ("x_max", "f4"),
+                ("features", "f4"),
+                ("xc", "f4"),
+                ("yc", "f4"),
+                ("zc", "f4"),
+                ("target", "f4"),
+                ("distance", "f4"),
+                ("passes_thresholds", "?"),
+            ]
+        ),
+        comments="#",
+        delimiter=",",
+        skip_header=1,
+    )
+    group = h5.create_group(h5.root, "spots")
+    table = h5.create_table(
+        group, description=data, name="table", title="table", expectedrows=len(data)
+    )
+    table.cols.ID.create_index()
+    table.cols.z.create_index()
+    table.cols.y.create_index()
+    table.cols.x.create_index()
+    table.cols.target.create_index()
+    h5.close()
+
+
+def query_hdf5(input, query):
+    t = tb.open_file(input)
+    try:
+        return list(t.root.spots.table.where(query))
+    finally:
+        t.close()

--- a/zarr_anndata/test_pytables.py
+++ b/zarr_anndata/test_pytables.py
@@ -1,0 +1,37 @@
+from functools import partial
+import os
+
+import pytest
+
+from zarr_anndata.pytables_util import write_pandas, write_tables, query_hdf5
+
+
+query = "(y > 2000) & (y < 3000) & (x > 1000) & (x < 2000)"
+
+
+def test_csv_to_hdf5_pandas(benchmark, tmp_path, request):
+    """Test writing csv to hdf5 with pandas"""
+
+    csv = f"{request.config.invocation_dir}/spots_reduced.csv"
+    filename = tmp_path / "pandas.h5"
+    setup_func = partial(write_pandas, input=csv, output=filename)
+    read_func = partial(query_hdf5, input=filename, query=query)
+    benchmark.pedantic(
+        read_func,
+        setup=setup_func,
+        rounds=20
+    )
+
+
+def test_csv_to_hdf5_tables(benchmark, tmp_path, request):
+    """Test writing csv to hdf5 with pandas"""
+
+    filename = tmp_path / "tables.h5"
+    csv = f"{request.config.invocation_dir}/spots_reduced.csv"
+    setup_func = partial(write_tables, input=csv, output=filename)
+    read_func = partial(query_hdf5, input=filename, query=query)
+    benchmark.pedantic(
+        read_func,
+        setup=setup_func,
+        rounds=20
+    )


### PR DESCRIPTION
Since PyTables has support for indices per column (https://www.pytables.org/usersguide/optimization.html#indexed-searches) this PR adds examples of converting the CSV to HDF5 for comparison to the Zarr access times.